### PR TITLE
Fixes Rhoban/Plater#6.

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -273,7 +273,7 @@ void MainWindow::on_wizard_accept()
         ui->parts->setText(parts);
     }
 
-    wizardNext();
+    QMetaObject::invokeMethod(this, &MainWindow::wizardNext, Qt::QueuedConnection);
 }
 
 void MainWindow::on_saveButton_clicked()


### PR DESCRIPTION
Delay deleting a Wizard object and creating a new one until the current one unwinds from the stack (wait until we return to the message loop).