### PR TITLE
Fixed drag-and-drop support

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 add_executable(plater-gui WIN32
   main.cpp
   mainwindow.cpp
+  partslist.cpp
   worker.cpp
   viewer.cpp
   wizard.cpp

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -12,7 +12,8 @@ TEMPLATE = app
 RC_FILE += gui.rc
 
 SOURCES += main.cpp\
-        mainwindow.cpp \
+    mainwindow.cpp \
+    partslist.cpp \
     worker.cpp \
     viewer.cpp \
     wizard.cpp \
@@ -20,6 +21,7 @@ SOURCES += main.cpp\
     about.cpp
 
 HEADERS  += mainwindow.h \
+    partslist.h \
     worker.h \
     viewer.h \
     wizard.h \

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -61,6 +61,17 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
+// Get the singleton instance of MainWindow
+MainWindow *MainWindow::instance()
+{
+    foreach (QWidget *w, qApp->topLevelWidgets()) {
+        if (MainWindow* mw = qobject_cast<MainWindow *>(w)) {
+            return mw;
+        }
+    }
+    return nullptr;
+}
+
 void MainWindow::updatePlateEnable()
 {
     if (ui->circularPlate->isChecked()) {
@@ -150,6 +161,13 @@ void MainWindow::wizardNext()
             wizard->setPlateDimension(getPlateWidth(), getPlateHeight());
         }
     }
+}
+
+// Add all parts from the list by invoking wizardNext() for each file.
+void MainWindow::addParts(QStringList stls)
+{
+    this->stls = stls;
+    wizardNext();
 }
 
 bool MainWindow::isCircular()

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -20,6 +20,8 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
+    // Get the singleton instance of MainWindow
+    static MainWindow *instance();
 
     void updatePlateEnable();
     void enableAll(bool enable);
@@ -33,6 +35,8 @@ public:
     Q_INVOKABLE
 #endif
     void wizardNext();
+    // Add all parts from the list by invoking wizardNext() for each file.
+    void addParts(QStringList stls);
     bool isCircular();
     float getPlateDiameter();
     float getPlateWidth();

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -30,7 +30,7 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
-         <widget class="QTextEdit" name="parts"/>
+         <widget class="PartsList" name="parts"/>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -458,7 +458,7 @@
      <x>0</x>
      <y>0</y>
      <width>690</width>
-     <height>33</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAbout">
@@ -538,12 +538,19 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>PartsList</class>
+   <extends>QTextEdit</extends>
+   <header>partslist.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="icons.qrc"/>
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/gui/partslist.cpp
+++ b/gui/partslist.cpp
@@ -1,0 +1,26 @@
+#include <QMimeData>
+#include <QUrl>
+#include "partslist.h"
+#include "mainwindow.h"
+
+// Invoked by QTextEdit's drop event handler
+void PartsList::insertFromMimeData(const QMimeData *source)
+{
+    // If the source has any URLs, see if they refer to local
+    // files. If so, convert them to local filesystem paths and add
+    // them to the parts list.
+    if (source->hasUrls()) {
+        QStringList stls;
+        for (auto url : source->urls()) {
+            if (url.isLocalFile()) {
+                stls.push_back(url.toLocalFile());
+            }
+        }
+        if (stls.size() > 0) {
+            MainWindow::instance()->addParts(stls);
+        }
+    } else {
+        // default handling
+        QTextEdit::insertFromMimeData(source);
+    }
+}

--- a/gui/partslist.h
+++ b/gui/partslist.h
@@ -1,0 +1,16 @@
+#ifndef PARTSLIST_H
+#define PARTSLIST_H
+
+#include <QTextEdit>
+
+class PartsList : public QTextEdit
+{
+    Q_OBJECT
+public:
+    PartsList(QWidget *parent = nullptr) : QTextEdit(parent) {}
+protected:
+    // Invoked by QTextEdit's drop event handler
+    virtual void insertFromMimeData(const QMimeData *source);
+};
+
+#endif // PARTSLIST_H


### PR DESCRIPTION
Fixed drag-and-drop support in the parts list widget to handle local file URLs. It is now possible to drag-and-drop multiple .stl files from a file explorer window.