### PR TITLE
Fixes issue Rhoban/Plater#8

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(plater-gui WIN32
   about.cpp
   icons.qrc
   gui.rc
+  plater-gui.manifest
 )
 
 if(MSVC)

--- a/gui/plater-gui.manifest
+++ b/gui/plater-gui.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="plater-gui" version="1.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/plater/CMakeLists.txt
+++ b/plater/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 target_include_directories(libplater PUBLIC .)
 target_link_libraries(libplater PRIVATE Threads::Threads)
 
-add_executable(plater "main.cpp")
+add_executable(plater main.cpp plater.manifest)
 if(MSVC)
   target_compile_options(plater PRIVATE /wd4244)
 endif()

--- a/plater/plater.manifest
+++ b/plater/plater.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="plater" version="1.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Set the process locale to UTF-8 on Windows using an embedded manifest. Note this only works on Windows 10 Version 1903 and later.